### PR TITLE
fix key_error_name

### DIFF
--- a/backend/utils/parse_notion.py
+++ b/backend/utils/parse_notion.py
@@ -81,10 +81,8 @@ def parse_notion_page(page: Raw_Notion_Page) -> Projet:
         chef_de_projet_ou_referent=[
             people(
                 id=prop["Chef de projet / Referent"]["people"][j]["id"],
-                name=prop["Chef de projet / Referent"]["people"][j]["name"],
-                avatar_url=prop["Chef de projet / Referent"]["people"][j]["avatar_url"]
-                if prop["Chef de projet / Referent"]["people"][j]["avatar_url"]
-                else None,
+                name=prop["Chef de projet / Referent"]["people"][j].get("name", ""),
+                avatar_url=prop["Chef de projet / Referent"]["people"][j].get("avatar_url", None),
             )
             for j in range(len(prop["Chef de projet / Referent"]["people"]))
         ]


### PR DESCRIPTION
Fix erreur dans le back sur le parse de la page notion.

Je ne sais pas pourquoi cette erreur apparait maintenant, mais je l'ai remarqué en allant sur l'appli déployée par curiosité et j'ai vu que les icônes des projets avec des images custom n'apparaissaient plus → les liens ont un délai d'expiration et donc c'est que le back n'envoyait plus les nouveaux liens → ce que j'ai pu vérifier vu que la requête vers /all_projets échouait...

J'ai pu observer l'erreur en local :
name=prop["Chef de projet / Referent"]["people"][j]["name"],
KeyError: 'name'
Ce que j'ai fix,

Je vous laisse review et approuver la PR @aangelot et @yannis et faire l'update de l'image pour vous entrainer si vous voulez (J'ai quand même, au cas où, réalisé une update de l'image sur docker hub "bapttheo/monitoring-projet-back", qu'il faudra dire à Pierre-Alexandre de mettre à jour.
